### PR TITLE
chomp the line in single_line mode

### DIFF
--- a/rb
+++ b/rb
@@ -7,6 +7,6 @@ rescue Errno::EPIPE
 end
 
 single_line = ARGV[0] == '-l'
-code = ARGV.drop(single_line ? 1 : 0).join(' ')
-code = eval("Proc.new { #{code} }")
-single_line ? STDIN.each { |l| execute(l, code) } : execute(STDIN.readlines, code)
+expr = ARGV.drop(single_line ? 1 : 0).join(' ')
+code = eval("Proc.new { #{expr} }")
+single_line ? STDIN.each { |l| execute(l.chomp, code) } : execute(STDIN.readlines, code)


### PR DESCRIPTION
In case one expects the result to be `3` instead of `4`:

    echo abc | rb -l size

💄 renaming the first `code` to `expr` for improved readability.